### PR TITLE
Use the internal load balancer ingress for team api

### DIFF
--- a/.nais/test.yaml
+++ b/.nais/test.yaml
@@ -48,6 +48,7 @@ spec:
       external:
         - host: 'auth.test.ssb.no'
         - host: 'data.ssb.no'
+        - host: 'dapla-team-api.intern.test.ssb.no'
 
   envFrom:
     - secret: login-config-dapla-ctrl # contains: WONDERWALL_OPENID_CLIENT_ID, WONDERWALL_OPENID_CLIENT_SECRET, WONDERWALL_OPENID_AUDIENCES
@@ -60,7 +61,7 @@ spec:
 
   env:
     - name: 'DAPLA_TEAM_API_URL'
-      value: 'http://dapla-team-api.dapla-platform' # uses Service discovery
+      value: 'https://dapla-team-api.intern.test.ssb.no' # use internal load balancer
     - name: 'DAPLA_CTRL_ADMIN_GROUPS'
       value: 'dapla-stat-developers,dapla-skyinfra-developers'
     - name: 'DAPLA_CTRL_DOCUMENTATION_URL'


### PR DESCRIPTION
Since team api now runs in 'dual' mode where one instance only serve shared-buckets endpoint, while the other has it disabled

internal ref: [DPSKY-1026]

[DPSKY-1026]: https://statistics-norway.atlassian.net/browse/DPSKY-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-ctrl/429)
<!-- Reviewable:end -->
